### PR TITLE
Adfurikunを停止

### DIFF
--- a/Assets/mainStage.unity
+++ b/Assets/mainStage.unity
@@ -37,7 +37,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311918, g: 0.3807398, b: 0.35872716, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311947, g: 0.38074005, b: 0.35872722, a: 1}
 --- !u!157 &4
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -6866,7 +6866,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1120686741
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
AdfurikunMovieRewardUtility.cs内のinitializeMovieRewardIOS_(appId)が呼ばれるとクラッシュするので、ゲームオブジェクトを非アクティブに変更